### PR TITLE
Adding links to clarify Hyperswarm

### DIFF
--- a/index.html
+++ b/index.html
@@ -454,7 +454,7 @@ aside.basealign {
             <ul>
                 <li><strong>Strengths.</strong> Fast, finds physically nearby peers, doesn’t need special infrastructure, works offline.</li>
                 <li><strong>Weaknesses.</strong> Limited reach.</li>
-                <li><strong>Deployment status.</strong> Currently in use, will be replaced by Hyperswarm in the future.</li>
+                <li><strong>Deployment status.</strong> Currently in use, will be replaced by <a href="https://pfrazee.hashbase.io/blog/hyperswarm">Hyperswarm</a> in the future.</li>
             </ul>
             <p>Local network discovery uses multicast DNS, which is like a regular DNS query except instead of sending queries to a nameserver they are broadcast to the local network with the hope that someone else on the network sees it and responds.</p>
             <figure class="pagewidth">
@@ -484,7 +484,7 @@ aside.basealign {
             <ul>
                 <li><strong>Strengths.</strong> Fast, global reach.</li>
                 <li><strong>Weaknesses.</strong> Must be online, centralized point of failure, one server sees everyone’s metadata.</li>
-                <li><strong>Deployment status.</strong> Currently in use, will be replaced by Hyperswarm in the future.</li>
+                <li><strong>Deployment status.</strong> Currently in use, will be replaced by <a href="https://pfrazee.hashbase.io/blog/hyperswarm">Hyperswarm</a> in the future.</li>
             </ul>
             <p>Currently the server running this is <strong>discovery1.datprotocol.com</strong>. If that goes offline then <strong>discovery2.datprotocol.com</strong> can be used as a fallback.</p>
             <p>Here is a typical message flow between a Dat peer and the DNS discovery server:</p>


### PR DESCRIPTION
Linking pfrazee's blog post (instead of linking the github account or one of its sub-repos, since the blog post is a narrative explanation more like this document).