### PR TITLE
Moving the Visual Index to the bottom

### DIFF
--- a/index.html
+++ b/index.html
@@ -513,87 +513,12 @@ aside.basealign, .impl {
                                 <div><a href="#paths-index">Paths index</a></div>
                             </div>
                             <div><a class="s1" href="#future-of-dat">Future of Dat</a></div>
+                            <div><a class="s1" href="#visual-index">Visual Index</a></div>
                         </div>
                     </div>
                 </div>
             </div>
             <div id="relversion">v1 • January 2019</div>
-
-            <h2 id="visualindexheader">Visual index</h2>
-            <div id="visualindex">
-                <div class="col">
-                    <a href="#introduction"><img src="png/visual_index/vi_introduction.png" width="160" height="94"/></a>
-                    <a href="#urls"><img src="png/visual_index/vi_urls.png" width="160" height="87"/></a>
-                    <a href="#discovery"><img src="png/visual_index/vi_discovery.png" width="160" height="37"/></a>
-                    <a href="#discovery-keys"><img src="png/visual_index/vi_discovery_keys.png" width="160" height="62"/></a>
-                    <a href="#blake2b"><img src="png/visual_index/vi_blake2b.png" width="160" height="79"/></a>
-                    <a href="#local-network-discovery"><img src="png/visual_index/vi_local_network_discovery.png" width="160" height="42"/></a>
-                    <a href="#mdns-request"><img src="png/visual_index/vi_mdns_request.png" width="160" height="108"/></a>
-                    <a href="#mdns-response"><img src="png/visual_index/vi_mdns_response.png" width="160" height="157"/></a>
-                    <a href="#mdns-peers-record"><img src="png/visual_index/vi_mdns_peers_record.png" width="160" height="92"/></a>
-                    <a href="#centralized-dns-discovery"><img src="png/visual_index/vi_centralized_dns_discovery.png" width="160" height="237"/></a>
-                </div>
-                <div class="col">
-                    <a href="#centralized-dns-peers-record"><img src="png/visual_index/vi_centralized_dns_peers_record.png" width="160" height="100"/></a>
-                    <a href="#centralized-dns-request"><img src="png/visual_index/vi_centralized_dns_request.png" width="160" height="172"/></a>
-                    <a href="#centralized-dns-response"><img src="png/visual_index/vi_centralized_dns_response.png" width="160" height="172"/></a>
-                    <a href="#centralized-dns-srv"><img src="png/visual_index/vi_centralized_dns_srv.png" width="160" height="122"/></a>
-                    <a href="#wire-protocol"><img src="png/visual_index/vi_wire_protocol.png" width="160" height="111"/></a>
-                    <a href="#message-type"><img src="png/visual_index/vi_message_type.png" width="160" height="67"/></a>
-                    <a href="#varints"><img src="png/visual_index/vi_varints.png" width="160" height="142"/></a>
-                    <a href="#keepalive"><img src="png/visual_index/vi_keepalive.png" width="160" height="66"/></a>
-                </div>
-                <div class="col">
-                    <a href="#message-structure"><img src="png/visual_index/vi_message_structure.png" width="160" height="59"/></a>
-                    <a href="#message-structure-field-tag"><img src="png/visual_index/vi_message_structure_field_tag.png" width="160" height="61"/></a>
-                    <a href="#message-field-types"><img src="png/visual_index/vi_message_field_types.png" width="160" height="69"/></a>
-                    <a href="#feed-message"><img src="png/visual_index/vi_feed_message.png" width="160" height="125"/></a>
-                    <a href="#feed-message-bytes"><img src="png/visual_index/vi_feed_message_bytes.png" width="160" height="78"/></a>
-                    <a href="#encryption"><img src="png/visual_index/vi_encryption.png" width="160" height="75"/></a>
-                    <a href="#encryption-sender"><img src="png/visual_index/vi_encryption_sender.png" width="160" height="82"/></a>
-                    <a href="#encryption-receiver"><img src="png/visual_index/vi_encryption_receiver.png" width="160" height="94"/></a>
-                    <a href="#handshake-message"><img src="png/visual_index/vi_handshake_message.png" width="160" height="73"/></a>
-                    <a href="#data-model"><img src="png/visual_index/vi_data_model.png" width="160" height="67"/></a>
-                    <a href="#chunk-structure-hashes"><img src="png/visual_index/vi_chunk_structure_hashes.png" width="160" height="50"/></a>
-                    <a href="#chunk-structure-signature"><img src="png/visual_index/vi_chunk_structure_signature.png" width="160" height="66"/></a>
-                </div>
-                <div class="col">
-                    <a href="#hash-tree-1"><img src="png/visual_index/vi_hash_tree_1.png" width="160" height="266"/></a>
-                    <a href="#hash-tree-2"><img src="png/visual_index/vi_hash_tree_2.png" width="160" height="238"/></a>
-                    <a href="#hashes-and-signatures"><img src="png/visual_index/vi_hashes_and_signatures.png" width="160" height="35"/></a>
-                    <a href="#chunk-hash"><img src="png/visual_index/vi_chunk_hash.png" width="160" height="59"/></a>
-                    <a href="#parent-hash"><img src="png/visual_index/vi_parent_hash.png" width="160" height="60"/></a>
-                    <a href="#root-hash"><img src="png/visual_index/vi_root_hash.png" width="160" height="130"/></a>
-                    <a href="#signature-verification"><img src="png/visual_index/vi_signature_verification.png" width="160" height="78"/></a>
-                </div>
-                <div class="col">
-                    <a href="#exchanging-data"><img src="png/visual_index/vi_exchanging_data.png" width="160" height="151"/></a>
-                    <a href="#want-and-have"><img src="png/visual_index/vi_want_and_have.png" width="160" height="69"/></a>
-                    <a href="#want-have-conversation-1"><img src="png/visual_index/vi_want_have_conversation_1.png" width="160" height="155"/></a>
-                    <a href="#want-have-conversation-2"><img src="png/visual_index/vi_want_have_conversation_2.png" width="160" height="169"/></a>
-                    <a href="#have-bitfield"><img src="png/visual_index/vi_have_bitfield.png" width="160" height="95"/></a>
-                    <a href="#have-bitfield-range-types"><img src="png/visual_index/vi_have_bitfield_range_types.png" width="160" height="114"/></a>
-                    <a href="#have-bitfield-bits"><img src="png/visual_index/vi_have_bitfield_bits.png" width="160" height="103"/></a>
-                    <a href="#have-bitfield-bytes"><img src="png/visual_index/vi_have_bitfield_bytes.png" width="160" height="38"/></a>
-                    <a href="#requesting-data"><img src="png/visual_index/vi_requesting_data.png" width="160" height="49"/></a>
-                    <a href="#cancel-message"><img src="png/visual_index/vi_cancel_message.png" width="160" height="33"/></a>
-                    <a href="#data-message"><img src="png/visual_index/vi_data_message.png" width="160" height="55"/></a>
-                </div>
-                <div class="col">
-                    <a href="#files-and-folders"><img src="png/visual_index/vi_files_and_folders.png" width="160" height="108"/></a>
-                    <a href="#node-fields"><img src="png/visual_index/vi_node_fields.png" width="160" height="129"/></a>
-                    <a href="#files-folders-feeds"><img src="png/visual_index/vi_files_folders_feeds.png" width="160" height="67"/></a>
-                    <a href="#paths-index"><img src="png/visual_index/vi_paths_index.png" width="160" height="68"/></a>
-                    <a href="#paths-index-tree"><img src="png/visual_index/vi_paths_index_tree.png" width="160" height="68"/></a>
-                    <a href="#paths-index-versions"><img src="png/visual_index/vi_paths_index_versions.png" width="160" height="68"/></a>
-                    <a href="#paths-index-select"><img src="png/visual_index/vi_paths_index_select.png" width="160" height="65"/></a>
-                    <a href="#paths-index-encode"><img src="png/visual_index/vi_paths_index_encode.png" width="160" height="92"/></a>
-                    <a href="#paths-index-delete"><img src="png/visual_index/vi_paths_index_delete.png" width="160" height="141"/></a>
-                    <a href="#future-of-dat"><img src="png/visual_index/vi_future_of_dat.png" width="160" height="140"/></a>
-                    <a href="#conclusion"><img src="png/visual_index/vi_conclusion.png" width="160" height="53"/></a>
-                </div>
-            </div>
-            <hr/>
 
             <p id="introduction"><strong>Dat is a protocol for sharing data between computers.</strong> Dat’s strengths are that data is hosted and distributed by many computers on the network, that it can work offline or with poor connectivity, that the original uploader can add or modify data while keeping a full history and that it can handle large amounts of data.</p>
             <div>
@@ -1501,6 +1426,84 @@ aside.basealign, .impl {
                     <p>Thank you for reading all the way to the end! Were there any parts that you found particularly useful or particularly frustrating? I rely on feedback from readers to learn where the sticking points are. Please <strong><a href="https://goo.gl/forms/R22N7C3e0trxNn9h1">send me feedback</a></strong> so that I can improve this guide for future readers.</p>
                 </div>
             </div>
+
+            <h1 id="visual-index" class="section" style="background-image: url(png/header_8.png)"><span>Visual Index</span></h1>
+
+            <div id="visualindex">
+                <div class="col">
+                    <a href="#introduction"><img src="png/visual_index/vi_introduction.png" width="160" height="94"/></a>
+                    <a href="#urls"><img src="png/visual_index/vi_urls.png" width="160" height="87"/></a>
+                    <a href="#discovery"><img src="png/visual_index/vi_discovery.png" width="160" height="37"/></a>
+                    <a href="#discovery-keys"><img src="png/visual_index/vi_discovery_keys.png" width="160" height="62"/></a>
+                    <a href="#blake2b"><img src="png/visual_index/vi_blake2b.png" width="160" height="79"/></a>
+                    <a href="#local-network-discovery"><img src="png/visual_index/vi_local_network_discovery.png" width="160" height="42"/></a>
+                    <a href="#mdns-request"><img src="png/visual_index/vi_mdns_request.png" width="160" height="108"/></a>
+                    <a href="#mdns-response"><img src="png/visual_index/vi_mdns_response.png" width="160" height="157"/></a>
+                    <a href="#mdns-peers-record"><img src="png/visual_index/vi_mdns_peers_record.png" width="160" height="92"/></a>
+                    <a href="#centralized-dns-discovery"><img src="png/visual_index/vi_centralized_dns_discovery.png" width="160" height="237"/></a>
+                </div>
+                <div class="col">
+                    <a href="#centralized-dns-peers-record"><img src="png/visual_index/vi_centralized_dns_peers_record.png" width="160" height="100"/></a>
+                    <a href="#centralized-dns-request"><img src="png/visual_index/vi_centralized_dns_request.png" width="160" height="172"/></a>
+                    <a href="#centralized-dns-response"><img src="png/visual_index/vi_centralized_dns_response.png" width="160" height="172"/></a>
+                    <a href="#centralized-dns-srv"><img src="png/visual_index/vi_centralized_dns_srv.png" width="160" height="122"/></a>
+                    <a href="#wire-protocol"><img src="png/visual_index/vi_wire_protocol.png" width="160" height="111"/></a>
+                    <a href="#message-type"><img src="png/visual_index/vi_message_type.png" width="160" height="67"/></a>
+                    <a href="#varints"><img src="png/visual_index/vi_varints.png" width="160" height="142"/></a>
+                    <a href="#keepalive"><img src="png/visual_index/vi_keepalive.png" width="160" height="66"/></a>
+                </div>
+                <div class="col">
+                    <a href="#message-structure"><img src="png/visual_index/vi_message_structure.png" width="160" height="59"/></a>
+                    <a href="#message-structure-field-tag"><img src="png/visual_index/vi_message_structure_field_tag.png" width="160" height="61"/></a>
+                    <a href="#message-field-types"><img src="png/visual_index/vi_message_field_types.png" width="160" height="69"/></a>
+                    <a href="#feed-message"><img src="png/visual_index/vi_feed_message.png" width="160" height="125"/></a>
+                    <a href="#feed-message-bytes"><img src="png/visual_index/vi_feed_message_bytes.png" width="160" height="78"/></a>
+                    <a href="#encryption"><img src="png/visual_index/vi_encryption.png" width="160" height="75"/></a>
+                    <a href="#encryption-sender"><img src="png/visual_index/vi_encryption_sender.png" width="160" height="82"/></a>
+                    <a href="#encryption-receiver"><img src="png/visual_index/vi_encryption_receiver.png" width="160" height="94"/></a>
+                    <a href="#handshake-message"><img src="png/visual_index/vi_handshake_message.png" width="160" height="73"/></a>
+                    <a href="#data-model"><img src="png/visual_index/vi_data_model.png" width="160" height="67"/></a>
+                    <a href="#chunk-structure-hashes"><img src="png/visual_index/vi_chunk_structure_hashes.png" width="160" height="50"/></a>
+                    <a href="#chunk-structure-signature"><img src="png/visual_index/vi_chunk_structure_signature.png" width="160" height="66"/></a>
+                </div>
+                <div class="col">
+                    <a href="#hash-tree-1"><img src="png/visual_index/vi_hash_tree_1.png" width="160" height="266"/></a>
+                    <a href="#hash-tree-2"><img src="png/visual_index/vi_hash_tree_2.png" width="160" height="238"/></a>
+                    <a href="#hashes-and-signatures"><img src="png/visual_index/vi_hashes_and_signatures.png" width="160" height="35"/></a>
+                    <a href="#chunk-hash"><img src="png/visual_index/vi_chunk_hash.png" width="160" height="59"/></a>
+                    <a href="#parent-hash"><img src="png/visual_index/vi_parent_hash.png" width="160" height="60"/></a>
+                    <a href="#root-hash"><img src="png/visual_index/vi_root_hash.png" width="160" height="130"/></a>
+                    <a href="#signature-verification"><img src="png/visual_index/vi_signature_verification.png" width="160" height="78"/></a>
+                </div>
+                <div class="col">
+                    <a href="#exchanging-data"><img src="png/visual_index/vi_exchanging_data.png" width="160" height="151"/></a>
+                    <a href="#want-and-have"><img src="png/visual_index/vi_want_and_have.png" width="160" height="69"/></a>
+                    <a href="#want-have-conversation-1"><img src="png/visual_index/vi_want_have_conversation_1.png" width="160" height="155"/></a>
+                    <a href="#want-have-conversation-2"><img src="png/visual_index/vi_want_have_conversation_2.png" width="160" height="169"/></a>
+                    <a href="#have-bitfield"><img src="png/visual_index/vi_have_bitfield.png" width="160" height="95"/></a>
+                    <a href="#have-bitfield-range-types"><img src="png/visual_index/vi_have_bitfield_range_types.png" width="160" height="114"/></a>
+                    <a href="#have-bitfield-bits"><img src="png/visual_index/vi_have_bitfield_bits.png" width="160" height="103"/></a>
+                    <a href="#have-bitfield-bytes"><img src="png/visual_index/vi_have_bitfield_bytes.png" width="160" height="38"/></a>
+                    <a href="#requesting-data"><img src="png/visual_index/vi_requesting_data.png" width="160" height="49"/></a>
+                    <a href="#cancel-message"><img src="png/visual_index/vi_cancel_message.png" width="160" height="33"/></a>
+                    <a href="#data-message"><img src="png/visual_index/vi_data_message.png" width="160" height="55"/></a>
+                </div>
+                <div class="col">
+                    <a href="#files-and-folders"><img src="png/visual_index/vi_files_and_folders.png" width="160" height="108"/></a>
+                    <a href="#node-fields"><img src="png/visual_index/vi_node_fields.png" width="160" height="129"/></a>
+                    <a href="#files-folders-feeds"><img src="png/visual_index/vi_files_folders_feeds.png" width="160" height="67"/></a>
+                    <a href="#paths-index"><img src="png/visual_index/vi_paths_index.png" width="160" height="68"/></a>
+                    <a href="#paths-index-tree"><img src="png/visual_index/vi_paths_index_tree.png" width="160" height="68"/></a>
+                    <a href="#paths-index-versions"><img src="png/visual_index/vi_paths_index_versions.png" width="160" height="68"/></a>
+                    <a href="#paths-index-select"><img src="png/visual_index/vi_paths_index_select.png" width="160" height="65"/></a>
+                    <a href="#paths-index-encode"><img src="png/visual_index/vi_paths_index_encode.png" width="160" height="92"/></a>
+                    <a href="#paths-index-delete"><img src="png/visual_index/vi_paths_index_delete.png" width="160" height="141"/></a>
+                    <a href="#future-of-dat"><img src="png/visual_index/vi_future_of_dat.png" width="160" height="140"/></a>
+                    <a href="#conclusion"><img src="png/visual_index/vi_conclusion.png" width="160" height="53"/></a>
+                </div>
+            </div>
+            <hr/>
+
 
         </main>
         <footer>


### PR DESCRIPTION
The visual index is a mass of confusion the moment you look at the page. This
commit moves it to the bottom while adding a link in the table of contents at
the top.

New link in table of contents:

![image](https://user-images.githubusercontent.com/266454/51816323-e253ad80-227a-11e9-8844-c9def718bac2.png)

New visual index at bottom with fancy header:

![image](https://user-images.githubusercontent.com/266454/51816391-365e9200-227b-11e9-9f49-81f95840f42b.png)

